### PR TITLE
Fix FOCUS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FOCUS (FinOps Open Source Cost and Usage Specification) Validator
-Validator resource for checking datasets against the (FOCUS)[focus.finops.org] specification.
+Validator resource for checking datasets against the [FOCUS](focus.finops.org) specification.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FOCUS (FinOps Open Source Cost and Usage Specification) Validator
-Validator resource for checking datasets against the [FOCUS](focus.finops.org) specification.
+Validator resource for checking datasets against the [FOCUS](https://focus.finops.org) specification.
 
 ## Overview
 


### PR DESCRIPTION
Fix link to the FOCUS page on the README