### PR TITLE
Add poetry helper to github actions (#81).

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,22 +7,38 @@ on:
       - issue/**
 
 jobs:
-    validate_focus:
-        runs-on: ubuntu-latest
-        permissions:
-          checks: write
-        steps:
-            - name: Check out repository code
-              uses: actions/checkout@v3
-            - name: super-step
-              shell: sh
-              run: |
-                pip3 install -r requirements.txt
-                python3 -m focus_validator.main --data-file tests/samples/all_pass.csv  --output-type unittest --output-destination reports/focus_tests.xml
-            - name: FOCUS Validation Report
-              uses: dorny/test-reporter@v1
-              if: success() || failure()    # run this step even if previous step failed
-              with:
-                name: FOCUS Validations
-                path: reports/*.xml         # Path to test results
-                reporter: java-junit        # Format of test results
+  validate_focus:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2
+      - name: Setup a local virtual environment
+        run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+          poetry lock
+      - uses: actions/cache@v3
+        name: Define a cache for the virtual environment based on the dependencies lock file
+        with:
+          path: ./.venv
+          key: venv-${{ hashFiles('poetry.lock') }}
+      - name: Install dependencies
+        run: |
+          poetry install
+      - name: super-step
+        shell: sh
+        run: |
+          poetry run focus-validator --data-file tests/samples/all_pass.csv  --output-type unittest --output-destination reports/focus_tests.xml
+      - name: FOCUS Validation Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: FOCUS Validations
+          path: reports/*.xml         # Path to test results
+          reporter: java-junit        # Format of test results

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
+          poetry lock
       - uses: actions/cache@v3
         name: Define a cache for the virtual environment based on the dependencies lock file
         with:


### PR DESCRIPTION
Since poetry run in its own virtualenv, we can no longer run the focus-validator commands directly in the github ci/cd environment. 
Therefore adding `poetry run focus-validator` to start the validator.